### PR TITLE
Add ability to detect iOS devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,13 @@ context.isDesktop
 context.isMobile
 context.isTablet
 context.isMobileOrTablet
+context.isIos
 
 instance.$device.isDesktop
 instance.$device.isMobile
 instance.$device.isTablet
 instance.$device.isMobileOrTablet
+instance.$device.isIos
 ```
 
 ## CloudFront Support

--- a/plugin.js
+++ b/plugin.js
@@ -16,6 +16,10 @@ const REGEX_MOBILE_OR_TABLET1 = /(android|bb\d+|meego).+mobile|avantgo|bada\/|bl
 // eslint-disable-next-line
 const REGEX_MOBILE_OR_TABLET2 = /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i
 
+function isIos (a) {
+  return /iPad|iPhone|iPod/.test(a)
+}
+
 function isMobileOrTablet (a) {
   return REGEX_MOBILE_OR_TABLET1.test(a) || REGEX_MOBILE_OR_TABLET2.test(a.substr(0, 4))
 }
@@ -39,27 +43,17 @@ export default async function (ctx, inject) {
   if (!userAgent) {
     userAgent = DEFAULT_USER_AGENT
   }
-  let mobile = null
-  let mobileOrTablet = null
-  if (userAgent === 'Amazon CloudFront') {
-    if (ctx.req.headers['cloudfront-is-mobile-viewer'] === 'true') {
-      mobile = true
-      mobileOrTablet = true
-    }
-    if (ctx.req.headers['cloudfront-is-tablet-viewer'] === 'true') {
-      mobile = false
-      mobileOrTablet = true
-    }
-  } else {
-    mobile = isMobile(userAgent)
-    mobileOrTablet = isMobileOrTablet(userAgent)
-  }
+  let mobile = isMobile(userAgent)
+  let mobileOrTablet = isMobileOrTablet(userAgent)
+  let ios = isIos(userAgent)
 
+  ctx.isIos = ios
   ctx.isMobile = mobile
   ctx.isMobileOrTablet = mobileOrTablet
   ctx.isTablet = !mobile && mobileOrTablet
   ctx.isDesktop = !mobileOrTablet
   inject('device', {
+    isIos: ios,
     isMobile: mobile,
     isMobileOrTablet: mobileOrTablet,
     isTablet: !mobile && mobileOrTablet,

--- a/plugin.js
+++ b/plugin.js
@@ -43,9 +43,23 @@ export default async function (ctx, inject) {
   if (!userAgent) {
     userAgent = DEFAULT_USER_AGENT
   }
-  let mobile = isMobile(userAgent)
-  let mobileOrTablet = isMobileOrTablet(userAgent)
-  let ios = isIos(userAgent)
+  let mobile = null
+  let mobileOrTablet = null
+  let ios = null
+  if (userAgent === 'Amazon CloudFront') {
+    if (ctx.req.headers['cloudfront-is-mobile-viewer'] === 'true') {
+      mobile = true
+      mobileOrTablet = true
+    }
+    if (ctx.req.headers['cloudfront-is-tablet-viewer'] === 'true') {
+      mobile = false
+      mobileOrTablet = true
+    }
+  } else {
+    mobile = isMobile(userAgent)
+    mobileOrTablet = isMobileOrTablet(userAgent)
+    ios = isIos(userAgent)
+  }
 
   ctx.isMobile = mobile
   ctx.isMobileOrTablet = mobileOrTablet
@@ -60,4 +74,3 @@ export default async function (ctx, inject) {
     isIos: ios
   })
 }
-

--- a/plugin.js
+++ b/plugin.js
@@ -16,12 +16,12 @@ const REGEX_MOBILE_OR_TABLET1 = /(android|bb\d+|meego).+mobile|avantgo|bada\/|bl
 // eslint-disable-next-line
 const REGEX_MOBILE_OR_TABLET2 = /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i
 
-function isIos (a) {
-  return /iPad|iPhone|iPod/.test(a)
-}
-
 function isMobileOrTablet (a) {
   return REGEX_MOBILE_OR_TABLET1.test(a) || REGEX_MOBILE_OR_TABLET2.test(a.substr(0, 4))
+}
+
+function isIos (a) {
+  return /iPad|iPhone|iPod/.test(a)
 }
 
 const DEFAULT_USER_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.39 Safari/537.36'
@@ -47,17 +47,17 @@ export default async function (ctx, inject) {
   let mobileOrTablet = isMobileOrTablet(userAgent)
   let ios = isIos(userAgent)
 
-  ctx.isIos = ios
   ctx.isMobile = mobile
   ctx.isMobileOrTablet = mobileOrTablet
   ctx.isTablet = !mobile && mobileOrTablet
   ctx.isDesktop = !mobileOrTablet
+  ctx.isIos = ios
   inject('device', {
-    isIos: ios,
     isMobile: mobile,
     isMobileOrTablet: mobileOrTablet,
     isTablet: !mobile && mobileOrTablet,
     isDesktop: !mobileOrTablet,
+    isIos: ios
   })
 }
 


### PR DESCRIPTION
This adds the ability to detect iOS devices. It checks the `userAgent` for instances of `iPad`, `iPod`, or `iPhone`. This matches the behavior of the existing boolean values for `isMobile`, `isTablet`, etc.